### PR TITLE
Add scroll position persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - Serve a specified PDF file via an HTTP server
 - View the PDF simply by accessing the server URL
 - Automatically reloads the browser to show the latest PDF when the file is updated
+- Remembers your position in the PDF when reloading
 - Accessible from other devices (PC, smartphone, tablet, etc.) on the same local network
 - Binds to `0.0.0.0` so other devices on your LAN can connect
 

--- a/index.js
+++ b/index.js
@@ -47,10 +47,23 @@ const { clear, debug, port, host } = flags;
 <style>html,body{height:100%;margin:0}embed{width:100%;height:100%}</style>
 <embed id="pdf" src="/pdf" type="application/pdf" />
 <script>
+const KEY = 'livepdf-scroll';
+const pdf = document.getElementById('pdf');
+const restore = () => {
+  const y = sessionStorage.getItem(KEY);
+  if (y !== null) window.scrollTo(0, parseFloat(y));
+};
+window.addEventListener('load', restore);
+pdf.addEventListener('load', restore);
+window.addEventListener('beforeunload', () => {
+  sessionStorage.setItem(KEY, window.scrollY);
+});
 const ws = new WebSocket('ws://' + location.host);
 ws.onmessage = (ev) => {
   if (ev.data === 'reload') {
-    document.getElementById('pdf').src = '/pdf?' + Date.now();
+    sessionStorage.setItem(KEY, window.scrollY);
+    pdf.addEventListener('load', restore, { once: true });
+    pdf.src = '/pdf?' + Date.now();
   }
 };
 </script>`);


### PR DESCRIPTION
## Summary
- remember scroll position between reloads and after reconnecting
- document the new behavior in the README

## Testing
- `npx prettier --check index.js README.md`

------
https://chatgpt.com/codex/tasks/task_e_6886c9d39ed4832185aa4487ac42ee0f